### PR TITLE
fix: in test mode log writing are sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ or by setting the environment variable `STANDARD_LOG`.
 Production mode:
 - log level defaults to `warn`
 - `config()` can only be called once
+- reporters receives the log entry after current operation (i.e. in `setImmediate()`)
 
 Development mode:
 - log level defaults to `debug`
 - calling `config()` multiple times will emit a warning
+- reporters receives the log entry after current operation (i.e. in `setImmediate()`)
 
 Test mode:
 - log level defaults to `debug`
+- reporters receives the log entry immediately.
 
 ### Log Level
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "commitlint-circle": "^1.0.0",
     "compression-webpack-plugin": "^3.0.0",
     "console-feed": "^2.8.8",
+    "delay": "^4.3.0",
     "husky": "^3.0.0",
     "lerna": "^3.15.0",
     "param-case": "^2.1.1",

--- a/packages/log/src/getLogger.spec.ts
+++ b/packages/log/src/getLogger.spec.ts
@@ -46,13 +46,13 @@ test('existing logger will get custom level', () => {
 describe('validate write to reporters', () => {
   let capture: ReturnType<typeof captureWrittenLog>
   beforeEach(() => {
+    config({ mode: 'test' })
     capture = captureWrittenLog()
   })
   afterEach(() => {
     capture.reset()
   })
   test('logger with custom level', async () => {
-    config({ mode: 'devel' })
     addCustomLogLevel('cust_lvl', 100)
     const logger = getLogger<'cust_lvl'>('cust')
     logger.cust_lvl('a', 'b')
@@ -61,7 +61,6 @@ describe('validate write to reporters', () => {
   })
   describe('count()', () => {
     test('will increment the counter', async () => {
-      config({ mode: 'test' })
       const logger = getLogger('inc counter')
 
       logger.count()
@@ -96,7 +95,7 @@ describe('validate write to reporters', () => {
 
   describe('log level tests', () => {
     beforeEach(() => {
-      setLogLevel(logLevel.error)
+      config({ mode: 'test', logLevel: logLevel.error })
     })
 
     afterEach(() => {

--- a/packages/log/src/logLevel.spec.ts
+++ b/packages/log/src/logLevel.spec.ts
@@ -23,18 +23,17 @@ afterAll(() => {
 describe('capture write to reporters', () => {
   let capture: ReturnType<typeof captureWrittenLog>
   beforeEach(() => {
+    config({ mode: 'test', logLevel: logLevel.error })
     capture = captureWrittenLog()
   })
   afterEach(() => {
     capture.reset()
   })
   test('no matched logger do no harm', async () => {
-    const reporter = createMemoryLogReporter()
-    store.value.reporters = [reporter]
-
     setLogLevels(/x/, logLevel.debug)
     const log = getLogger('filter1')
     log.debug('abc')
+
     expect(capture.logs.length).toEqual(0)
   })
   describe('setLogLevels()', () => {

--- a/packages/log/src/utils/writeToReporters.spec.ts
+++ b/packages/log/src/utils/writeToReporters.spec.ts
@@ -1,0 +1,15 @@
+import { captureWrittenLog } from '../testUtil';
+import { config } from '..';
+import { getLogger } from '../getLogger';
+import delay from 'delay'
+
+test('in non test mode the logs are sent to reporters out of band', async () => {
+  config({ mode: 'devel' })
+  const c = captureWrittenLog()
+  const log = getLogger('delay-write')
+  log.emergency('ouch')
+
+  expect(c.logs.length).toBe(0)
+  await delay(10)
+  expect(c.logs.length).toBe(1)
+})

--- a/packages/log/src/utils/writeToReporters.ts
+++ b/packages/log/src/utils/writeToReporters.ts
@@ -2,13 +2,13 @@ import { store } from '../store';
 import { LogEntry } from '../types';
 
 export function writeToReporters(logEntry: LogEntry) {
-  writeToReporters.fn(logEntry)
+  if (store.value.mode === 'test')
+    writeToReporters.fn(logEntry)
+  else
+    setImmediate(() => writeToReporters.fn(logEntry))
 }
 
+// istanbul ignore next
 writeToReporters.fn = (logEntry: LogEntry) => {
-  if (store.value.mode === 'test')
-    store.value.reporters.forEach(r => r.write(logEntry!))
-  else
-    // istanbul ignore next
-    setImmediate(() => store.value.reporters.forEach(r => r.write(logEntry!)))
+  store.value.reporters.forEach(r => r.write(logEntry!))
 }

--- a/packages/log/src/utils/writeToReporters.ts
+++ b/packages/log/src/utils/writeToReporters.ts
@@ -6,6 +6,9 @@ export function writeToReporters(logEntry: LogEntry) {
 }
 
 writeToReporters.fn = (logEntry: LogEntry) => {
-  // istanbul ignore next
-  setImmediate(() => store.value.reporters.forEach(r => r.write(logEntry!)))
+  if (store.value.mode === 'test')
+    store.value.reporters.forEach(r => r.write(logEntry!))
+  else
+    // istanbul ignore next
+    setImmediate(() => store.value.reporters.forEach(r => r.write(logEntry!)))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5286,6 +5286,11 @@ defined@^1.0.0:
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
+delay@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-4.3.0.tgz#efeebfb8f545579cb396b3a722443ec96d14c50e"
+  integrity sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
Some test runner (jest) will rightfully complain the log is called out of band.