### PR TITLE
fix(color): use local isBrowser

### DIFF
--- a/packages/color/src/createColorLogReporter.ts
+++ b/packages/color/src/createColorLogReporter.ts
@@ -1,8 +1,8 @@
-import { ConsoleLogReporterOptions, createConsoleLogReporter, isBrowser, plainLogFormatter } from 'standard-log';
+import { ConsoleLogReporterOptions, createConsoleLogReporter, plainLogFormatter } from 'standard-log';
 import { required } from 'unpartial';
 import { createAnsiFormatter } from './ansi';
 import { createCssFormatter } from './css';
-import { supportColor } from './utils';
+import { isBrowser, supportColor } from './utils';
 
 export function createColorLogReporter(options?: ConsoleLogReporterOptions) {
   return createConsoleLogReporter(required({ id: 'console', formatter: getFormatter() }, options))

--- a/packages/color/src/utils/index.ts
+++ b/packages/color/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './isBrowser';
 export * from './supportColor';

--- a/packages/color/src/utils/isBrowser.ts
+++ b/packages/color/src/utils/isBrowser.ts
@@ -1,0 +1,5 @@
+export function isBrowser() {
+  const p: any = process
+  // tslint:disable-next-line: strict-type-predicates
+  return (typeof process === 'undefined' || p.type === 'renderer' || p.browser === true || p.__nwjs)
+}

--- a/packages/color/src/utils/supportColor.ts
+++ b/packages/color/src/utils/supportColor.ts
@@ -1,4 +1,4 @@
-import { isBrowser } from 'standard-log';
+import { isBrowser } from './isBrowser';
 
 export function supportColor() {
   return isBrowser() ? doesBrowserSupportColor() : true


### PR DESCRIPTION
The seems to be a circular reference issue,

as `standard-log` will try to load `color` during load time.