### PR TITLE
feat: add config.isLocked

### DIFF
--- a/packages/log/src/config.spec.ts
+++ b/packages/log/src/config.spec.ts
@@ -55,7 +55,7 @@ test('configure as devel will emit warning', () => {
 })
 
 test('config.configured', () => {
-  expect(config.isLocked()).toBeFalsy()
+  expect(config.isLocked).toBeFalsy()
   config({ mode: 'test' })
-  expect(config.isLocked()).toBe(true)
+  expect(config.isLocked).toBe(true)
 })

--- a/packages/log/src/config.spec.ts
+++ b/packages/log/src/config.spec.ts
@@ -53,3 +53,9 @@ test('configure as devel will emit warning', () => {
 
   console.warn = warn
 })
+
+test('config.configured', () => {
+  expect(config.isLocked()).toBeFalsy()
+  config({ mode: 'test' })
+  expect(config.isLocked()).toBe(true)
+})

--- a/packages/log/src/config.ts
+++ b/packages/log/src/config.ts
@@ -14,7 +14,7 @@ export type ConfigOptions = {
   reporters: LogReporter[]
 }
 
-export function config(options: Partial<ConfigOptions> = {}) {
+export const config: { (options?: Partial<ConfigOptions>): void, readonly isLocked: boolean } = function config(options: Partial<ConfigOptions> = {}) {
   if (store.value.configured && store.value.mode === 'production') {
     throw new ProhibitedDuringProduction('config')
   }
@@ -41,9 +41,13 @@ export function config(options: Partial<ConfigOptions> = {}) {
   else if (store.value.mode === 'development') {
     console.warn(`'standard-log' is configured in 'development' mode. Configuration is not protected.`)
   }
-}
+} as any
 
-/**
- * Gets if the config has already been locked
- */
-config.isLocked = () => store.value.configured
+Object.defineProperty(config, 'isLocked', {
+  /**
+   * Gets if the config has already been locked
+   */
+  get() {
+    return store.value.configured
+  }
+})

--- a/packages/log/src/config.ts
+++ b/packages/log/src/config.ts
@@ -36,10 +36,14 @@ export function config(options: Partial<ConfigOptions> = {}) {
 
   if (store.value.mode === 'production') {
     store.freeze({ ...store.value, reporters: Object.freeze(store.value.reporters) })
-    // eslint-disable-next-line no-console
-    console.debug(`'standard-log' is running in 'production' mode with log level '${toLogLevelName(store.value.logLevel)}'`)
+    console.info(`'standard-log' is running in 'production' mode with log level '${toLogLevelName(store.value.logLevel)}'`)
   }
   else if (store.value.mode === 'development') {
     console.warn(`'standard-log' is configured in 'development' mode. Configuration is not protected.`)
   }
 }
+
+/**
+ * Gets if the config has already been locked
+ */
+config.isLocked = () => store.value.configured


### PR DESCRIPTION
This can be used by middleware to determine if it can call config() or not.

fix: change the production message to console.info().
It is better to be upfront during production so consumer can detect things are off it they do not see this message.