### PR TITLE
feat: add logger.write(entry)

### DIFF
--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -174,6 +174,9 @@ test('your test', () => {
 
   a.satisfies(logs, [{ args: ['some messages']}])
   a.equals('miku', result)
+
+  // rewriting the logs
+  logs.forEach(entry => log.write(entry))
 })
 ```
 

--- a/packages/log/src/getLogger.spec.ts
+++ b/packages/log/src/getLogger.spec.ts
@@ -1,10 +1,10 @@
-import a from 'assertron';
-import delay from 'delay';
-import { addCustomLogLevel, clearCustomLogLevel, getLogger, InvalidId, Logger, logLevels, LogMethodNames, setLogLevel, toLogLevel, toLogLevelName } from '.';
-import { config } from './config';
-import { createMemoryLogReporter, MemoryLogReporter } from './memory';
-import { store } from './store';
-import { captureWrittenLog } from './testUtil';
+import a from 'assertron'
+import delay from 'delay'
+import { addCustomLogLevel, clearCustomLogLevel, getLogger, InvalidId, Logger, logLevels, LogMethodNames, setLogLevel, toLogLevel, toLogLevelName } from '.'
+import { config } from './config'
+import { createMemoryLogReporter, MemoryLogReporter } from './memory'
+import { store } from './store'
+import { captureWrittenLog } from './testUtil'
 
 afterEach(() => {
   clearCustomLogLevel()
@@ -83,7 +83,7 @@ describe('validate write to reporters', () => {
 
     test('append args after the counter', async () => {
       store.value.logLevel = logLevels.debug
-      const id = 'inc with args';
+      const id = 'inc with args'
       const logger = getLogger(id)
       logger.count('msg1', 'msg2')
 
@@ -94,7 +94,7 @@ describe('validate write to reporters', () => {
 
     test('not log if log level is less than debug', async () => {
       store.value.logLevel = logLevels.debug - 1
-      const id = 'inc with args';
+      const id = 'inc with args'
       const logger = getLogger(id)
       logger.count('msg1', 'msg2')
 
@@ -351,7 +351,6 @@ describe('validate write to reporters', () => {
     shouldCallLogFunctionWithLocalLevelOverride(logLevels.debug, logLevels.debug)
   })
 
-
   test('on() log using log argument', () => {
     store.value.mode = 'test'
     store.value.logLevel = logLevels.debug
@@ -362,6 +361,13 @@ describe('validate write to reporters', () => {
     a.satisfies(capture.logs, [
       { id: 'log on fn', level: logLevels.error, args: ['value'] }
     ])
+  })
+
+  test('write entry directly', () => {
+    const log = getLogger('write-entry')
+    const entry = { id: 'write-entry', level: logLevels.info, args: ['abc'], timestamp: new Date() }
+    log.write(entry)
+    a.satisfies(capture.logs, [entry])
   })
 })
 

--- a/packages/log/src/getLogger.ts
+++ b/packages/log/src/getLogger.ts
@@ -1,11 +1,11 @@
-import { InvalidId } from './errors';
-import { logLevels } from './logLevel';
-import { getAllLogLevels, toLogLevel, toLogLevelName } from './logLevelFn';
-import { shouldLog } from './shouldLog';
-import { store } from './store';
-import { LogFunction, Logger, LogMethodNames, ReporterFilter } from './types';
-import { LoggerClosure } from './typesInternal';
-import { writeToReporters } from './writeToReporters';
+import { InvalidId } from './errors'
+import { logLevels } from './logLevel'
+import { getAllLogLevels, toLogLevel, toLogLevelName } from './logLevelFn'
+import { shouldLog } from './shouldLog'
+import { store } from './store'
+import { LogEntry, LogFunction, Logger, LogMethodNames, ReporterFilter } from './types'
+import { LoggerClosure } from './typesInternal'
+import { writeToReporters } from './writeToReporters'
 
 export namespace getLogger {
   export type Options = {
@@ -14,7 +14,9 @@ export namespace getLogger {
   }
 }
 
-export function getLogger<T extends string = LogMethodNames>(id: string, options?: getLogger.Options): Logger<T | LogMethodNames> {
+export function getLogger<T extends string = LogMethodNames>(
+  id: string, options?: getLogger.Options
+): Logger<T | LogMethodNames> {
   validateId(id)
   const loggerClosures = store.value.loggerClosures
   const loggerClosure: any = loggerClosures[id] || (loggerClosures[id] = createLoggerClosure<T | LogMethodNames>(id, options))
@@ -29,8 +31,12 @@ function createLoggerClosure<T extends string>(id: string, { level, writeTo = ()
   const filter: (reporterId: string) => boolean = typeof writeTo === 'string' ? id => id === writeTo :
     writeTo instanceof RegExp ? id => writeTo.test(id) : writeTo
 
+  function write(entry: LogEntry) {
+    writeToReporters(entry, filter)
+  }
   const logger = {
     level,
+    write
   } as any
 
   Object.defineProperties(logger, {
@@ -40,22 +46,22 @@ function createLoggerClosure<T extends string>(id: string, { level, writeTo = ()
       value: ((counter) => (...args: any[]) => {
         const level = logLevels.debug
         if (shouldLog(level, logger.level))
-          writeToReporters({
+          write({
             id,
             level,
             args: [++counter, ...args],
             timestamp: new Date()
-          }, filter)
+          })
       })(0)
     },
     on: {
       writable: false,
-      value: (level: number | T, logfn: LogFunction) => {
+      value: (level: number | T, logFn: LogFunction) => {
         const logLevel = typeof level === 'string' ? toLogLevel(level)! : level
         if (shouldLog(logLevel, logger.level)) {
           const methodName = toLogLevelName(logLevel)
           const bindedMethod = logger[methodName].bind(logger)
-          const result = logfn(bindedMethod)
+          const result = logFn(bindedMethod)
           if (result) bindedMethod(result)
         }
       }
@@ -66,7 +72,7 @@ function createLoggerClosure<T extends string>(id: string, { level, writeTo = ()
       Object.defineProperty(logger, name, {
         writable: false,
         value: (...args: any[]) => {
-          if (shouldLog(level, logger.level)) writeToReporters({ id, level, args, timestamp: new Date() }, filter)
+          if (shouldLog(level, logger.level)) write({ id, level, args, timestamp: new Date() })
         }
       })
     },

--- a/packages/log/src/types.ts
+++ b/packages/log/src/types.ts
@@ -5,6 +5,14 @@ export type LogMethodNames = 'emergency' | 'alert' | 'critical' | 'error' | 'war
 export type LogMethod = (...args: any[]) => void
 export type LogFunction = ((log: LogMethod) => void) | (() => string)
 
+export type LogEntry = {
+  id: string,
+  level: number,
+  // args instead of messages because it is `any[]` instead of `string[]`
+  args: any[],
+  timestamp: Date
+}
+
 export type Logger<T extends string = LogMethodNames> = {
   readonly id: string,
   /**
@@ -17,17 +25,14 @@ export type Logger<T extends string = LogMethodNames> = {
    */
   count(...args: any[]): void,
   on(level: number | T, logFunction: LogFunction): void,
+  /**
+   * Write custom log entries.
+   * This can be used along with `captureLogs()` to rewrite the logs at a later time.
+   */
+  write(entry: LogEntry): void
 } & {
     [k in T]: LogMethod
   }
-
-export type LogEntry = {
-  id: string,
-  level: number,
-  // args instead of messages because it is `any[]` instead of `string[]`
-  args: any[],
-  timestamp: Date
-}
 
 export type ReporterFilter = string | RegExp | ((reporterId: string) => boolean)
 


### PR DESCRIPTION
This is typically used with `captureLogs()`,
to rewrite the captured logs at a later time.