### PR TITLE
fix: remove production log

### DIFF
--- a/packages/log/src/config.spec.ts
+++ b/packages/log/src/config.spec.ts
@@ -53,7 +53,7 @@ test('configure as devel will emit warning', () => {
   console.warn = message => actual = message
   config({ mode: 'development' })
 
-  expect(actual!).toBe(`'standard-log' is configured in 'development' mode. Configuration is not protected.`)
+  expect(actual!).toBe(`'standard-log' is running in 'development' mode. Configuration is not protected.`)
 
   console.warn = warn
 })

--- a/packages/log/src/config.ts
+++ b/packages/log/src/config.ts
@@ -2,7 +2,6 @@ import { forEachKey } from 'type-plus'
 import { addCustomLogLevel } from './customLogLevel'
 import { ProhibitedDuringProduction } from './errors'
 import { getDefaultReporter } from './getDefaultReporter'
-import { toLogLevelName } from './logLevelFn'
 import { store } from './store'
 import { LogMode, LogReporter } from './types'
 
@@ -34,10 +33,9 @@ export const config: { (options?: Partial<ConfigOptions>): void, readonly isLock
 
   if (store.value.mode === 'production') {
     store.freeze({ ...store.value, reporters: Object.freeze(store.value.reporters) })
-    console.info(`'standard-log' is running in 'production' mode with log level '${toLogLevelName(store.value.logLevel)}'`)
   }
   else if (store.value.mode === 'development') {
-    console.warn(`'standard-log' is configured in 'development' mode. Configuration is not protected.`)
+    console.warn(`'standard-log' is running in 'development' mode. Configuration is not protected.`)
   }
 } as any
 

--- a/packages/log/src/errors.ts
+++ b/packages/log/src/errors.ts
@@ -18,7 +18,7 @@ export class ProhibitedDuringProduction extends StandardLogError {
 }
 
 export class InvalidEnvVar extends StandardLogError {
-  constructor(public name: string, public value: string, public possibleValues?: string[]) {
-    super(`${name} contains invalid value '${value}'${possibleValues ? ` valid values: [${possibleValues.join()}]` : ''}`)
+  constructor(public name: string, public value: string, public possibleValues: string[]) {
+    super(`${name} contains invalid value '${value}'${` valid values: [${possibleValues.join()}]`}`)
   }
 }


### PR DESCRIPTION
It is more of an distraction,
especially in cli usage.

Printing out warning when `standard-log` is running in dev mode should be sufficient.