### PR TITLE
feat: getLogger can specify a custom reporter

### DIFF
--- a/packages/log/src/getLogger.spec.ts
+++ b/packages/log/src/getLogger.spec.ts
@@ -425,6 +425,14 @@ describe('writeTo', () => {
     expect(memReporter.logs.length).toEqual(0)
     expect(specialReporter.logs.length).toEqual(1)
   })
+
+  test('custom reporter', () => {
+    const reporter = createMemoryLogReporter({ id: 'custom mem' })
+    const log = getLogger('writeTo-fn', { writeTo: reporter })
+    log.error('error message')
+
+    expect(reporter.logs.length).toEqual(1)
+  })
 })
 
 test('id is readonly', () => {

--- a/packages/log/src/logReporter.ts
+++ b/packages/log/src/logReporter.ts
@@ -1,24 +1,11 @@
+import { addLogReporterInternal } from './logReporterInternal'
 import { store } from './store';
 import { LogReporter } from './types';
 import { assertLogModeIsNotProduction } from './utils';
 
 export function addLogReporter(reporter: LogReporter) {
   assertLogModeIsNotProduction('addLogReporter')
-  if (reporter.isConsoleReporter) {
-    const i = store.value.reporters.findIndex(r => r.isConsoleReporter)
-    const r = store.value.reporters[i]
-    store.value.reporters.splice(i, 1)
-    if (r.filter) {
-      if (reporter.filter) {
-        const f2 = reporter.filter
-        reporter.filter = entry => r.filter!(entry) && f2(entry)
-      }
-      else {
-        reporter.filter = r.filter
-      }
-    }
-  }
-  store.value.reporters.push(reporter)
+  addLogReporterInternal(reporter)
 }
 
 export function getLogReporter(id: string) {

--- a/packages/log/src/logReporterInternal.ts
+++ b/packages/log/src/logReporterInternal.ts
@@ -1,0 +1,20 @@
+import { store } from './store'
+import { LogReporter } from './types'
+
+export function addLogReporterInternal(reporter: LogReporter) {
+  if (reporter.isConsoleReporter) {
+    const i = store.value.reporters.findIndex(r => r.isConsoleReporter)
+    const r = store.value.reporters[i]
+    store.value.reporters.splice(i, 1)
+    if (r.filter) {
+      if (reporter.filter) {
+        const f2 = reporter.filter
+        reporter.filter = entry => r.filter!(entry) && f2(entry)
+      }
+      else {
+        reporter.filter = r.filter
+      }
+    }
+  }
+  store.value.reporters.push(reporter)
+}


### PR DESCRIPTION
This allow code to create a logger for their internal use.

Since the logger is only created if it has not been created before,
allowing it to use its own reporter will not create security concerns.