### PR TITLE
fix: console reporter will not be replaced

### DIFF
--- a/packages/log/src/getLogger.spec.ts
+++ b/packages/log/src/getLogger.spec.ts
@@ -428,10 +428,22 @@ describe('writeTo', () => {
 
   test('custom reporter', () => {
     const reporter = createMemoryLogReporter({ id: 'custom mem' })
-    const log = getLogger('writeTo-fn', { writeTo: reporter })
+    const log = getLogger('writeTo-reporter', { writeTo: reporter })
     log.error('error message')
 
     expect(reporter.logs.length).toEqual(1)
+  })
+
+  test('custom reporter cannot override added console reporter', () => {
+    // if not, it would be a security issue as the new reporter
+    // can capture the logs from other logger and send it elsewhere
+    const reporter = createMemoryLogReporter({ id: 'custom mem' })
+    reporter.isConsoleReporter = true
+    getLogger('writeTo-reporter-no-override', { writeTo: reporter })
+    const log = getLogger('writeTo-reporter-no-override-2')
+    log.error('error message')
+
+    expect(reporter.logs.length).toEqual(0)
   })
 })
 

--- a/packages/log/src/logReporter.spec.ts
+++ b/packages/log/src/logReporter.spec.ts
@@ -4,7 +4,7 @@ import { store } from './store';
 import { createConsoleLogReporter } from './console';
 import { LogFilter } from './types';
 import { logLevels } from './logLevel';
-import { hasConsoleReporter } from './logReporter';
+import { getConsoleReporter, hasConsoleReporter } from './logReporter';
 
 beforeEach(() => {
   store.reset()
@@ -27,27 +27,27 @@ describe('addLogReporter()', () => {
   })
 
   describe('add another console reporter', () => {
-    test('will replace existing one', () => {
+    test('will not replace existing one', () => {
       expect(getLogReporter('console')).toBeDefined()
       addLogReporter(createConsoleLogReporter({ id: 'c2' }))
-      expect(getLogReporter('c2')).toBeDefined()
-      expect(getLogReporter('console')).toBeUndefined()
+      expect(getLogReporter('c2')).toBeUndefined()
+      expect(getLogReporter('console')).toBeDefined()
     })
 
     test('will carry over existing filter', () => {
       const filter: LogFilter = entry => entry.level < logLevels.alert
       addLogReporter(createConsoleLogReporter({ id: 'c2', filter }))
       addLogReporter(createConsoleLogReporter({ id: 'c3' }))
-      const c3 = getLogReporter('c3')!
+      const c3 = getConsoleReporter()!
       expect(c3.filter).toBe(filter)
     })
 
     test('will combine existing filter and new filter', () => {
       addLogReporter(createConsoleLogReporter({ id: 'c2', filter: entry => entry.level > logLevels.critical }))
       addLogReporter(createConsoleLogReporter({ id: 'c3', filter: entry => entry.level < logLevels.error }))
-      const c3 = getLogReporter('c3')!
-      expect(c3.filter({ level: logLevels.info } as any)).toBe(false)
-      expect(c3.filter({ level: logLevels.alert } as any)).toBe(false)
+      const c2 = getConsoleReporter()!
+      expect(c2.filter!({ level: logLevels.info } as any)).toBe(false)
+      expect(c2.filter!({ level: logLevels.alert } as any)).toBe(false)
     })
   })
 })

--- a/packages/log/src/logReporter.ts
+++ b/packages/log/src/logReporter.ts
@@ -16,6 +16,10 @@ export function hasConsoleReporter() {
   return store.value.reporters.some(r => r.isConsoleReporter)
 }
 
+export function getConsoleReporter() {
+  return store.value.reporters.find(r => r.isConsoleReporter)
+}
+
 export function clearLogReporters() {
   assertLogModeIsNotProduction('clearLogReporters')
   store.value.reporters.splice(0, store.value.reporters.length)

--- a/packages/log/src/logReporterInternal.ts
+++ b/packages/log/src/logReporterInternal.ts
@@ -1,23 +1,18 @@
+import { getConsoleReporter } from './logReporter'
 import { store } from './store'
 import { LogReporter } from './types'
 
 export function addLogReporterInternal(reporter: LogReporter) {
   if (reporter.isConsoleReporter) {
-    const i = store.value.reporters.findIndex(r => r.isConsoleReporter)
-    if (i >= 0) {
-      const r = store.value.reporters[i]
-      store.value.reporters.splice(i, 1)
-      if (r.filter) {
-        const f = r.filter
-        if (reporter.filter) {
-          const f2 = reporter.filter
-          reporter.filter = entry => f(entry) && f2(entry)
-        }
-        else {
-          reporter.filter = r.filter
-        }
-      }
+    const r = getConsoleReporter()
+    if (r && reporter.filter) {
+      const f = r.filter
+      const f2 = reporter.filter
+      if (f) r.filter = entry => f(entry) && f2(entry)
+      else r.filter = f2
     }
   }
-  store.value.reporters.push(reporter)
+  else {
+    store.value.reporters.push(reporter)
+  }
 }


### PR DESCRIPTION
It would be a security problem if it can be replaced.
The original one will be used.
One the new filter will be incorporated
(should this be allows is still debateable)