### PR TITLE
fix: allow making `config()` call during tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "changesets",
     "cust",
     "Greenkeeper",
+    "miku",
     "syslog",
     "tsbuildinfo",
     "uglifyjs",

--- a/packages/color/src/createColorLogReporter.spec.ts
+++ b/packages/color/src/createColorLogReporter.spec.ts
@@ -1,8 +1,10 @@
-import { addCustomLogLevel, clearCustomLogLevel, ConsoleLogFormatter, LogFilter, logLevels, plainLogFormatter, config } from 'standard-log'
+import {
+  addCustomLogLevel, clearCustomLogLevel, configForTest,
+  ConsoleLogFormatter, LogFilter, logLevels, plainLogFormatter
+} from 'standard-log'
 import { createAnsiFormatter, createColorLogReporter, createCssFormatter } from '.'
-beforeAll(() => {
-  config({ mode: 'test' })
-})
+
+beforeAll(() => configForTest())
 
 describe('rendering tests', () => {
   test('default to color rendering', () => {

--- a/packages/log/src/config.spec.ts
+++ b/packages/log/src/config.spec.ts
@@ -1,5 +1,9 @@
 import a from 'assertron'
-import { config, createMemoryLogReporter, logLevels, ProhibitedDuringProduction, toLogLevelName } from '.'
+import {
+  config, createMemoryLogReporter,
+  logLevels, ProhibitedDuringProduction, toLogLevelName
+} from '.'
+import { configForTest } from './configForTest'
 import { store } from './store'
 
 beforeEach(() => store.reset())
@@ -15,9 +19,7 @@ test('default logLevel is info', () => {
 })
 
 test('configure default logLevel', () => {
-  config({
-    logLevel: logLevels.planck
-  })
+  config({ logLevel: logLevels.planck })
 
   expect(store.value.logLevel).toBe(logLevels.planck)
 })
@@ -25,6 +27,12 @@ test('configure default logLevel', () => {
 test('calling config twice throws ProhibitedDuringProduction in production mode', () => {
   config({ mode: 'production' })
   a.throws(() => config({ mode: 'development' }), ProhibitedDuringProduction)
+})
+
+test('calling config twice in test mode is allowed, but emit a warning', () => {
+  const { reporter } = configForTest()
+  config({ mode: 'production' })
+  expect(reporter.getLogMessageWithLevel()).toEqual('(WARN) already configured for test, ignoring config() call')
 })
 
 test('add custom levels', () => {

--- a/packages/log/src/config.ts
+++ b/packages/log/src/config.ts
@@ -2,6 +2,7 @@ import { forEachKey } from 'type-plus'
 import { addCustomLogLevel } from './customLogLevel'
 import { ProhibitedDuringProduction } from './errors'
 import { getDefaultReporter } from './getDefaultReporter'
+import { getLogger } from './getLogger'
 import { store } from './store'
 import { LogMode, LogReporter } from './types'
 
@@ -13,8 +14,15 @@ export type ConfigOptions = {
 }
 
 export const config: { (options?: Partial<ConfigOptions>): void, readonly isLocked: boolean } = function config(options: Partial<ConfigOptions> = {}) {
-  if (store.value.configured && store.value.mode === 'production') {
-    throw new ProhibitedDuringProduction('config')
+  if (store.value.configured) {
+    if (store.value.mode === 'production') {
+      throw new ProhibitedDuringProduction('config')
+    }
+    if (store.value.mode === 'test') {
+      const log = getLogger('standard-log')
+      log.warn(`already configured for test, ignoring config() call`)
+      return
+    }
   }
 
   if (options.mode) store.value.mode = options.mode

--- a/packages/log/src/configForTest.ts
+++ b/packages/log/src/configForTest.ts
@@ -1,9 +1,11 @@
 import { config } from './config'
 import { createMemoryLogReporter } from './memory'
+import { store } from './store'
 import { LogLevel } from './types'
 
 
 export function configForTest(logLevel?: LogLevel) {
+  store.reset()
   const reporter = createMemoryLogReporter()
   config({
     reporters: [reporter],

--- a/packages/log/src/console/createConsoleLogReporter.spec.ts
+++ b/packages/log/src/console/createConsoleLogReporter.spec.ts
@@ -1,130 +1,21 @@
-import a from 'assertron';
-import { addCustomLogLevel, clearCustomLogLevel, ConsoleLogFormatter, createConsoleLogReporter, LogFilter, logLevels, plainLogFormatter } from '..';
-import { config } from '../config';
-import { ProhibitedDuringProduction } from '../errors';
-import { store } from '../store';
+import a from 'assertron'
+import {
+  addCustomLogLevel, clearCustomLogLevel, config, configForTest,
+  ConsoleLogFormatter, createConsoleLogReporter,
+  LogFilter, logLevels, plainLogFormatter, ProhibitedDuringProduction
+} from '..'
+import { store } from '../store'
 
-beforeEach(() => {
-  store.reset()
-  config({ mode: 'test' })
-})
+describe('production checks', () => {
+  beforeEach(() => store.reset())
 
-describe('rendering tests', () => {
-  test('plain rendering', () => {
-    const reporter = createConsoleLogReporter({ formatter: plainLogFormatter });
-    ['emergency', 'info', 'warn', 'debug'].forEach(level => {
-      reporter.write({ id: 'plain', level: (logLevels as any)[level], args: ['hello', 'world'], timestamp: new Date() })
-    })
-  })
-})
-
-describe('id', () => {
-  test('default is "console"', () => {
+  test('set filter during production mode throws', () => {
+    config({ mode: 'production' })
     const reporter = createConsoleLogReporter()
-    expect(reporter.id).toBe('console')
-  })
-  test('can be overridden', () => {
-    const reporter = createConsoleLogReporter({ id: 'neo-console' })
-    expect(reporter.id).toBe('neo-console')
-  })
-})
-
-describe('log level', () => {
-  test('error, alert, critical and emergency logs are written to console.error', () => {
-    const id = 'log'
-    const reporter = createConsoleLogReporter()
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.critical, args: ['critical'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.alert, args: ['alert'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.error, args: ['error'], timestamp: new Date() })
-
-    expect(fakeConsole.errors.length).toBe(4)
+    a.throws(() => { reporter.filter = () => true }, ProhibitedDuringProduction)
   })
 
-  test('warn logs are written to console.warn', () => {
-    const id = 'log'
-    const reporter = createConsoleLogReporter()
-
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: logLevels.warn, args: ['warn'], timestamp: new Date() })
-
-    expect(fakeConsole.warns.length).toBe(1)
-  })
-
-  test('notice and info logs are written to console.info', () => {
-    const id = 'log'
-    const reporter = createConsoleLogReporter()
-
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: logLevels.notice, args: ['notice'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.info, args: ['info'], timestamp: new Date() })
-
-    expect(fakeConsole.infos.length).toBe(2)
-  })
-
-
-  test('debug, trace, and planck logs are written to console.debug', () => {
-    const id = 'log'
-    const reporter = createConsoleLogReporter()
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: logLevels.debug, args: ['debug'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.trace, args: ['trace'], timestamp: new Date() })
-    reporter.write({ id, level: logLevels.planck, args: ['planck'], timestamp: new Date() })
-
-    expect(fakeConsole.debugs.length).toBe(3)
-  })
-})
-
-describe('custom logs', () => {
-  afterEach(() => clearCustomLogLevel())
-
-  test('are written according to their log level value', () => {
-    addCustomLogLevel('high', 50)
-    addCustomLogLevel('important', 450)
-    addCustomLogLevel('interest', 650)
-    addCustomLogLevel('silly', 1000)
-
-    const id = 'log'
-    const reporter = createConsoleLogReporter()
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: 50, args: ['a'], timestamp: new Date() })
-    reporter.write({ id, level: 450, args: ['b'], timestamp: new Date() })
-    reporter.write({ id, level: 650, args: ['c'], timestamp: new Date() })
-    reporter.write({ id, level: 1000, args: ['d'], timestamp: new Date() })
-
-    expect(fakeConsole.errors.length).toBe(1)
-    expect(fakeConsole.warns.length).toBe(1)
-    expect(fakeConsole.infos.length).toBe(1)
-    expect(fakeConsole.debugs.length).toBe(1)
-  })
-})
-
-const idFormatter: ConsoleLogFormatter = (entry) => [entry.id]
-
-describe('formatter', () => {
-  test('use specific formatter', () => {
-    const id = 'id-only'
-    const reporter = createConsoleLogReporter({ formatter: idFormatter })
-    const fakeConsole = reporter.console = createFakeConsole();
-
-    reporter.write({ id, level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
-
-    expect(fakeConsole.errors).toEqual([['id-only']])
-  })
-
-  test('formatter can be changed afterward', () => {
-    const reporter = createConsoleLogReporter()
-    const formatter = reporter.formatter
-    reporter.formatter = idFormatter
-    expect(reporter.formatter).not.toEqual(formatter)
-  })
-
+  const idFormatter: ConsoleLogFormatter = (entry) => [entry.id]
   test('set formatter during production mode throws', () => {
     config({ mode: 'production' })
     const reporter = createConsoleLogReporter()
@@ -132,45 +23,162 @@ describe('formatter', () => {
   })
 })
 
-describe('filter', () => {
-  const filter: LogFilter = (entry) => entry.id !== 'secret'
-  test('use specific filter', () => {
-    const reporter = createConsoleLogReporter({ formatter: idFormatter, filter })
-    const fakeConsole = reporter.console = createFakeConsole();
 
-    reporter.write({ id: 'normal', level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
-    reporter.write({ id: 'secret', level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
+describe('unit tests', () => {
+  beforeEach(() => configForTest())
 
-    expect(fakeConsole.errors).toEqual([['normal']])
+  describe('rendering tests', () => {
+    test('plain rendering', () => {
+      const reporter = createConsoleLogReporter({ formatter: plainLogFormatter });
+      ['emergency', 'info', 'warn', 'debug'].forEach(level => {
+        reporter.write({ id: 'plain', level: (logLevels as any)[level], args: ['hello', 'world'], timestamp: new Date() })
+      })
+    })
   })
 
-  test('can change filter', () => {
-    const reporter = createConsoleLogReporter()
-    const filter = reporter.filter
-    reporter.filter = entry => entry.id !== 'secret'
-    expect(reporter.filter).not.toEqual(filter)
+  describe('id', () => {
+    test('default is "console"', () => {
+      const reporter = createConsoleLogReporter()
+      expect(reporter.id).toBe('console')
+    })
+    test('can be overridden', () => {
+      const reporter = createConsoleLogReporter({ id: 'neo-console' })
+      expect(reporter.id).toBe('neo-console')
+    })
   })
 
-  test('set filter during production mode throws', () => {
-    config({ mode: 'production' })
-    const reporter = createConsoleLogReporter()
-    a.throws(() => { reporter.filter = () => true }, ProhibitedDuringProduction)
+  describe('log level', () => {
+    test('error, alert, critical and emergency logs are written to console.error', () => {
+      const id = 'log'
+      const reporter = createConsoleLogReporter()
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.critical, args: ['critical'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.alert, args: ['alert'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.error, args: ['error'], timestamp: new Date() })
+
+      expect(fakeConsole.errors.length).toBe(4)
+    })
+
+    test('warn logs are written to console.warn', () => {
+      const id = 'log'
+      const reporter = createConsoleLogReporter()
+
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: logLevels.warn, args: ['warn'], timestamp: new Date() })
+
+      expect(fakeConsole.warns.length).toBe(1)
+    })
+
+    test('notice and info logs are written to console.info', () => {
+      const id = 'log'
+      const reporter = createConsoleLogReporter()
+
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: logLevels.notice, args: ['notice'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.info, args: ['info'], timestamp: new Date() })
+
+      expect(fakeConsole.infos.length).toBe(2)
+    })
+
+
+    test('debug, trace, and planck logs are written to console.debug', () => {
+      const id = 'log'
+      const reporter = createConsoleLogReporter()
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: logLevels.debug, args: ['debug'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.trace, args: ['trace'], timestamp: new Date() })
+      reporter.write({ id, level: logLevels.planck, args: ['planck'], timestamp: new Date() })
+
+      expect(fakeConsole.debugs.length).toBe(3)
+    })
+  })
+
+  describe('custom logs', () => {
+    afterEach(() => clearCustomLogLevel())
+
+    test('are written according to their log level value', () => {
+      addCustomLogLevel('high', 50)
+      addCustomLogLevel('important', 450)
+      addCustomLogLevel('interest', 650)
+      addCustomLogLevel('silly', 1000)
+
+      const id = 'log'
+      const reporter = createConsoleLogReporter()
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: 50, args: ['a'], timestamp: new Date() })
+      reporter.write({ id, level: 450, args: ['b'], timestamp: new Date() })
+      reporter.write({ id, level: 650, args: ['c'], timestamp: new Date() })
+      reporter.write({ id, level: 1000, args: ['d'], timestamp: new Date() })
+
+      expect(fakeConsole.errors.length).toBe(1)
+      expect(fakeConsole.warns.length).toBe(1)
+      expect(fakeConsole.infos.length).toBe(1)
+      expect(fakeConsole.debugs.length).toBe(1)
+    })
+  })
+
+  const idFormatter: ConsoleLogFormatter = (entry) => [entry.id]
+
+  describe('formatter', () => {
+    test('use specific formatter', () => {
+      const id = 'id-only'
+      const reporter = createConsoleLogReporter({ formatter: idFormatter })
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id, level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
+
+      expect(fakeConsole.errors).toEqual([['id-only']])
+    })
+
+    test('formatter can be changed afterward', () => {
+      const reporter = createConsoleLogReporter()
+      const formatter = reporter.formatter
+      reporter.formatter = idFormatter
+      expect(reporter.formatter).not.toEqual(formatter)
+    })
+  })
+
+  describe('filter', () => {
+    const filter: LogFilter = (entry) => entry.id !== 'secret'
+    test('use specific filter', () => {
+      const reporter = createConsoleLogReporter({ formatter: idFormatter, filter })
+      const fakeConsole = reporter.console = createFakeConsole()
+
+      reporter.write({ id: 'normal', level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
+      reporter.write({ id: 'secret', level: logLevels.emergency, args: ['emergency'], timestamp: new Date() })
+
+      expect(fakeConsole.errors).toEqual([['normal']])
+    })
+
+    test('can change filter', () => {
+      const reporter = createConsoleLogReporter()
+      const filter = reporter.filter
+      reporter.filter = entry => entry.id !== 'secret'
+      expect(reporter.filter).not.toEqual(filter)
+    })
+  })
+
+  test('write log entry with multiple arguments', () => {
+    const id = 'log'
+    const reporter = createConsoleLogReporter({ formatter: plainLogFormatter })
+    const fakeConsole = reporter.console = createFakeConsole()
+
+    const entry = { id, level: logLevels.info, args: ['a', 'b', 'c'], timestamp: new Date() }
+
+    reporter.write(entry)
+
+    expect(fakeConsole.infos).toEqual([
+      [entry.timestamp.toISOString(), 'log', '(INFO)', 'a', 'b', 'c']
+    ])
   })
 })
 
-test('write log entry with multiple arguments', () => {
-  const id = 'log'
-  const reporter = createConsoleLogReporter({ formatter: plainLogFormatter })
-  const fakeConsole = reporter.console = createFakeConsole();
-
-  const entry = { id, level: logLevels.info, args: ['a', 'b', 'c'], timestamp: new Date() }
-
-  reporter.write(entry)
-
-  expect(fakeConsole.infos).toEqual([
-    [entry.timestamp.toISOString(), 'log', '(INFO)', 'a', 'b', 'c']
-  ])
-})
 
 function createFakeConsole() {
   const errors: any[] = []

--- a/packages/log/src/logReporter.spec.ts
+++ b/packages/log/src/logReporter.spec.ts
@@ -1,88 +1,99 @@
-import a from 'assertron';
-import { addLogReporter, clearLogReporters, config, createMemoryLogReporter, getLogReporter, ProhibitedDuringProduction } from '.';
-import { store } from './store';
-import { createConsoleLogReporter } from './console';
-import { LogFilter } from './types';
-import { logLevels } from './logLevel';
-import { getConsoleReporter, hasConsoleReporter } from './logReporter';
+import a from 'assertron'
+import {
+  addLogReporter, clearLogReporters, config,
+  createConsoleLogReporter, createMemoryLogReporter,
+  getConsoleReporter, getLogReporter, hasConsoleReporter,
+  LogFilter, logLevels, ProhibitedDuringProduction
+} from '.'
+import { store } from './store'
 
-beforeEach(() => {
-  store.reset()
-  config({ mode: 'test' })
+describe('production checks', () => {
+  beforeEach(() => store.reset())
+
+  describe('addLogReporter()', () => {
+    test('throws in production mode', () => {
+      config({ mode: 'production' })
+      const reporter = createMemoryLogReporter()
+      a.throws(() => addLogReporter(reporter), ProhibitedDuringProduction)
+    })
+  })
+
+  describe('clearLogReporters()', () => {
+    test('throws in production mode', () => {
+      config({ mode: 'production' })
+      a.throws(() => clearLogReporters(), ProhibitedDuringProduction)
+    })
+  })
 })
 
-describe('addLogReporter()', () => {
-  test('throws in production mode', () => {
-    config({ mode: 'production' })
-    const reporter = createMemoryLogReporter()
-    a.throws(() => addLogReporter(reporter), ProhibitedDuringProduction)
+describe('unit tests', () => {
+  beforeEach(() => {
+    store.reset()
+    config({ mode: 'test' })
   })
 
-  test('adds log reporter', () => {
-    const count = store.value.reporters.length
-    const reporter = createMemoryLogReporter()
-    addLogReporter(reporter)
+  describe('addLogReporter()', () => {
+    test('adds log reporter', () => {
+      const count = store.value.reporters.length
+      const reporter = createMemoryLogReporter()
+      addLogReporter(reporter)
 
-    expect(store.value.reporters.length).toBe(count + 1)
+      expect(store.value.reporters.length).toBe(count + 1)
+    })
+
+    describe('add another console reporter', () => {
+      test('will not replace existing one', () => {
+        expect(getLogReporter('console')).toBeDefined()
+        addLogReporter(createConsoleLogReporter({ id: 'c2' }))
+        expect(getLogReporter('c2')).toBeUndefined()
+        expect(getLogReporter('console')).toBeDefined()
+      })
+
+      test('will carry over existing filter', () => {
+        const filter: LogFilter = entry => entry.level < logLevels.alert
+        addLogReporter(createConsoleLogReporter({ id: 'c2', filter }))
+        addLogReporter(createConsoleLogReporter({ id: 'c3' }))
+        const c3 = getConsoleReporter()!
+        expect(c3.filter).toBe(filter)
+      })
+
+      test('will combine existing filter and new filter', () => {
+        addLogReporter(createConsoleLogReporter({ id: 'c2', filter: entry => entry.level > logLevels.critical }))
+        addLogReporter(createConsoleLogReporter({ id: 'c3', filter: entry => entry.level < logLevels.error }))
+        const c2 = getConsoleReporter()!
+        expect(c2.filter!({ level: logLevels.info } as any)).toBe(false)
+        expect(c2.filter!({ level: logLevels.alert } as any)).toBe(false)
+      })
+    })
   })
 
-  describe('add another console reporter', () => {
-    test('will not replace existing one', () => {
+  describe('getLogReporter()', () => {
+    test('get log reporter by id', () => {
       expect(getLogReporter('console')).toBeDefined()
-      addLogReporter(createConsoleLogReporter({ id: 'c2' }))
-      expect(getLogReporter('c2')).toBeUndefined()
-      expect(getLogReporter('console')).toBeDefined()
     })
 
-    test('will carry over existing filter', () => {
-      const filter: LogFilter = entry => entry.level < logLevels.alert
-      addLogReporter(createConsoleLogReporter({ id: 'c2', filter }))
-      addLogReporter(createConsoleLogReporter({ id: 'c3' }))
-      const c3 = getConsoleReporter()!
-      expect(c3.filter).toBe(filter)
-    })
-
-    test('will combine existing filter and new filter', () => {
-      addLogReporter(createConsoleLogReporter({ id: 'c2', filter: entry => entry.level > logLevels.critical }))
-      addLogReporter(createConsoleLogReporter({ id: 'c3', filter: entry => entry.level < logLevels.error }))
-      const c2 = getConsoleReporter()!
-      expect(c2.filter!({ level: logLevels.info } as any)).toBe(false)
-      expect(c2.filter!({ level: logLevels.alert } as any)).toBe(false)
+    test('get log reporter with unknown id gets undefined', () => {
+      expect(getLogReporter('blah')).toBeUndefined()
     })
   })
-})
 
-describe('getLogReporter()', () => {
-  test('get log reporter by id', () => {
-    expect(getLogReporter('console')).toBeDefined()
+  describe('clearLogReporters()', () => {
+    test('removes all reporters', () => {
+      clearLogReporters()
+
+      expect(store.value.reporters.length).toBe(0)
+    })
   })
 
-  test('get log reporter with unknown id gets undefined', () => {
-    expect(getLogReporter('blah')).toBeUndefined()
-  })
-})
-
-describe('clearLogReporters()', () => {
-  test('throws in production mode', () => {
-    config({ mode: 'production' })
-    a.throws(() => clearLogReporters(), ProhibitedDuringProduction)
-  })
-
-  test('removes all reporters', () => {
-    clearLogReporters()
-
-    expect(store.value.reporters.length).toBe(0)
-  })
-})
-
-describe('hasConsoleReporter()', () => {
-  test('returns true if there is a console reporter', () => {
-    expect(hasConsoleReporter()).toBeTruthy()
-  })
-  test('returns false if there is no console reporter', () => {
-    clearLogReporters()
-    expect(hasConsoleReporter()).toBeFalsy()
-    addLogReporter(createMemoryLogReporter())
-    expect(hasConsoleReporter()).toBeFalsy()
+  describe('hasConsoleReporter()', () => {
+    test('returns true if there is a console reporter', () => {
+      expect(hasConsoleReporter()).toBeTruthy()
+    })
+    test('returns false if there is no console reporter', () => {
+      clearLogReporters()
+      expect(hasConsoleReporter()).toBeFalsy()
+      addLogReporter(createMemoryLogReporter())
+      expect(hasConsoleReporter()).toBeFalsy()
+    })
   })
 })

--- a/packages/log/src/memory/MemoryLogReporter.spec.ts
+++ b/packages/log/src/memory/MemoryLogReporter.spec.ts
@@ -2,97 +2,102 @@ import a from 'assertron'
 import { config, createMemoryLogReporter, logLevels, ProhibitedDuringProduction } from '..'
 import { store } from '../store'
 
-beforeEach(() => {
-  store.reset()
-  config({ mode: 'test' })
-})
-test('log entries are saved in the `logs` property', () => {
-  const reporter = createMemoryLogReporter()
-  const entry = { id: 'log', level: 1, args: ['some messages'], timestamp: new Date() }
-  reporter.write(entry)
-  expect(reporter.logs).toEqual([entry])
+describe('production checks', () => {
+  beforeEach(() => store.reset())
+  test('set formatter in production mode throws', () => {
+    config({ mode: 'production' })
+    const reporter = createMemoryLogReporter()
+
+    a.throws(() => { reporter.formatter = e => e }, ProhibitedDuringProduction)
+  })
+
+  test('set filter in production mode throws', () => {
+    config({ mode: 'production' })
+    const reporter = createMemoryLogReporter()
+    a.throws(() => { reporter.filter = () => true }, ProhibitedDuringProduction)
+  })
 })
 
-test('can override id', () => {
-  const reporter = createMemoryLogReporter({ id: 'custom-id-mem' })
-  expect(reporter.id).toBe('custom-id-mem')
-})
+describe('unit tests', () => {
+  beforeEach(() => {
+    store.reset()
+    config({ mode: 'test' })
+  })
+  test('log entries are saved in the `logs` property', () => {
+    const reporter = createMemoryLogReporter()
+    const entry = { id: 'log', level: 1, args: ['some messages'], timestamp: new Date() }
+    reporter.write(entry)
+    expect(reporter.logs).toEqual([entry])
+  })
 
-test('can filter', () => {
-  const reporter = createMemoryLogReporter({ filter(entry) { return entry.id !== 'secret' } })
-  reporter.write({ id: 'ok', level: 1, args: ['some messages'], timestamp: new Date() })
-  reporter.write({ id: 'secret', level: 1, args: ['some messages'], timestamp: new Date() })
-  expect(reporter.logs.length).toBe(1)
-})
+  test('can override id', () => {
+    const reporter = createMemoryLogReporter({ id: 'custom-id-mem' })
+    expect(reporter.id).toBe('custom-id-mem')
+  })
 
-test('can change filter', () => {
-  const reporter = createMemoryLogReporter()
-  const filter = reporter.filter
-  reporter.filter = entry => entry.id !== 'secret'
-  expect(reporter.filter).not.toEqual(filter)
-})
+  test('can filter', () => {
+    const reporter = createMemoryLogReporter({ filter(entry) { return entry.id !== 'secret' } })
+    reporter.write({ id: 'ok', level: 1, args: ['some messages'], timestamp: new Date() })
+    reporter.write({ id: 'secret', level: 1, args: ['some messages'], timestamp: new Date() })
+    expect(reporter.logs.length).toBe(1)
+  })
 
-test('set filter in production mode throws', () => {
-  config({ mode: 'production' })
-  const reporter = createMemoryLogReporter()
-  a.throws(() => { reporter.filter = () => true }, ProhibitedDuringProduction)
-})
+  test('can change filter', () => {
+    const reporter = createMemoryLogReporter()
+    const filter = reporter.filter
+    reporter.filter = entry => entry.id !== 'secret'
+    expect(reporter.filter).not.toEqual(filter)
+  })
 
-test('formatter can be used to pre-process the log', () => {
-  const reporter = createMemoryLogReporter({
-    formatter: (entry) => ({
-      ...entry,
-      args: entry.args.map(arg => arg === 'secret' ? '<censored>' : arg)
+  test('formatter can be used to pre-process the log', () => {
+    const reporter = createMemoryLogReporter({
+      formatter: (entry) => ({
+        ...entry,
+        args: entry.args.map(arg => arg === 'secret' ? '<censored>' : arg)
+      })
+    })
+
+    const entry = { id: 'log', level: 1, args: ['a', 'secret', 'b'], timestamp: new Date() }
+    reporter.write(entry)
+
+    expect(reporter.logs[0].args[1]).toBe('<censored>')
+  })
+
+  test('can change formatter', () => {
+    const reporter = createMemoryLogReporter()
+    const formatter = reporter.formatter
+    reporter.formatter = e => ({ ...e, args: e.args.reverse() })
+    expect(reporter.formatter).not.toEqual(formatter)
+  })
+
+  describe('getLogMessages()', () => {
+    test('empty logs returns empty string', () => {
+      const reporter = createMemoryLogReporter()
+
+      expect(reporter.getLogMessage()).toEqual('')
+    })
+
+    test('print args', () => {
+      const reporter = createMemoryLogReporter()
+      const entry = { id: 'log', level: 1, args: ['miku', 'is', 'singing'], timestamp: new Date() }
+      reporter.write(entry)
+      expect(reporter.getLogMessage()).toEqual('miku is singing')
+    })
+
+    test('print object arg', () => {
+      const reporter = createMemoryLogReporter()
+      const entry = { id: 'log', level: 1, args: [{ 'miku': 'sing' }], timestamp: new Date() }
+      reporter.write(entry)
+      expect(reporter.getLogMessage()).toEqual("{ miku: 'sing' }")
     })
   })
 
-  const entry = { id: 'log', level: 1, args: ['a', 'secret', 'b'], timestamp: new Date() }
-  reporter.write(entry)
-
-  expect(reporter.logs[0].args[1]).toBe('<censored>')
-})
-
-test('can change formatter', () => {
-  const reporter = createMemoryLogReporter()
-  const formatter = reporter.formatter
-  reporter.formatter = e => ({ ...e, args: e.args.reverse() })
-  expect(reporter.formatter).not.toEqual(formatter)
-})
-
-test('set formatter in production mode throws', () => {
-  config({ mode: 'production' })
-  const reporter = createMemoryLogReporter()
-
-  a.throws(() => { reporter.formatter = e => e }, ProhibitedDuringProduction)
-})
-
-describe('getLogMessages()', () => {
-  test('empty logs returns empty string', () => {
-    const reporter = createMemoryLogReporter()
-
-    expect(reporter.getLogMessage()).toEqual('')
-  })
-
-  test('print args', () => {
-    const reporter = createMemoryLogReporter()
-    const entry = { id: 'log', level: 1, args: ['miku', 'is', 'singing'], timestamp: new Date() }
-    reporter.write(entry)
-    expect(reporter.getLogMessage()).toEqual('miku is singing')
-  })
-
-  test('print object arg', () => {
-    const reporter = createMemoryLogReporter()
-    const entry = { id: 'log', level: 1, args: [{ 'miku': 'sing' }], timestamp: new Date() }
-    reporter.write(entry)
-    expect(reporter.getLogMessage()).toEqual("{ miku: 'sing' }")
-  })
-})
-
-describe('getLogMessageWithLevel', () => {
-  test('print with level', () => {
-    const reporter = createMemoryLogReporter()
-    reporter.write({ id: 'log', level: logLevels.info, args: ['msg 1'], timestamp: new Date() })
-    reporter.write({ id: 'log', level: logLevels.warn, args: ['msg 2'], timestamp: new Date() })
-    expect(reporter.getLogMessageWithLevel()).toEqual(`(INFO) msg 1\n(WARN) msg 2`)
+  describe('getLogMessageWithLevel', () => {
+    test('print with level', () => {
+      const reporter = createMemoryLogReporter()
+      reporter.write({ id: 'log', level: logLevels.info, args: ['msg 1'], timestamp: new Date() })
+      reporter.write({ id: 'log', level: logLevels.warn, args: ['msg 2'], timestamp: new Date() })
+      expect(reporter.getLogMessageWithLevel()).toEqual(`(INFO) msg 1\n(WARN) msg 2`)
+    })
   })
 })


### PR DESCRIPTION
It will emit a warning.

BREAKING CHANGE: config behavior changed

while this shouldn't be an issue,
marking this as a breaking change in case this causes any suprises.