### PR TITLE
fix: skip warning for config in test again

### DIFF
--- a/packages/log/src/config.spec.ts
+++ b/packages/log/src/config.spec.ts
@@ -29,11 +29,18 @@ test('calling config twice throws ProhibitedDuringProduction in production mode'
   a.throws(() => config({ mode: 'development' }), ProhibitedDuringProduction)
 })
 
-test('calling config twice in test mode is allowed, but emit a warning', () => {
+test('allow calling config with non-test mode while already running in test mode, but emit a warning', () => {
   const { reporter } = configForTest()
   config({ mode: 'production' })
   expect(reporter.getLogMessageWithLevel()).toEqual('(WARN) already configured for test, ignoring config() call')
 })
+
+test('allow calling config in test mode again while in test mode. Emit no warning', () => {
+  const { reporter } = configForTest()
+  config({ mode: 'test' })
+  expect(reporter.getLogMessageWithLevel()).toEqual('')
+})
+
 
 test('add custom levels', () => {
   config({

--- a/packages/log/src/config.ts
+++ b/packages/log/src/config.ts
@@ -18,7 +18,7 @@ export const config: { (options?: Partial<ConfigOptions>): void, readonly isLock
     if (store.value.mode === 'production') {
       throw new ProhibitedDuringProduction('config')
     }
-    if (store.value.mode === 'test') {
+    if (store.value.mode === 'test' && options.mode !== 'test') {
       const log = getLogger('standard-log')
       log.warn(`already configured for test, ignoring config() call`)
       return


### PR DESCRIPTION
This is normal as you call `configForTest()` on each test