### PR TITLE
fix(log): provide default log method names

### DIFF
--- a/.changeset/sixty-gifts-lick.md
+++ b/.changeset/sixty-gifts-lick.md
@@ -1,0 +1,5 @@
+---
+"standard-log": patch
+---
+
+Fix log methods props in generic environment

--- a/packages/log/ts/logger.ts
+++ b/packages/log/ts/logger.ts
@@ -5,9 +5,9 @@ import { LogStore } from './logStore.js'
 import type { LogEntry, LogFunction, Logger, LoggerOptions, LogMethodNames, LogReporter } from './types.js'
 import { LogLevel } from './types.js'
 
-export function createLogger<T extends string = LogMethodNames>(
+export function createLogger<N extends string = LogMethodNames>(
   store: LogStore, id: string, options?: LoggerOptions
-): Logger {
+): Logger<N | LogMethodNames> {
   validateId(id, options)
   const writeTo = options?.writeTo ?? (() => true)
   const [filter, reporters]: [(reporterId: string) => boolean, LogReporter[]] = typeof writeTo === 'string'
@@ -44,7 +44,7 @@ export function createLogger<T extends string = LogMethodNames>(
     },
     on: {
       writable: false,
-      value: (level: number | T, logFn: LogFunction) => {
+      value: (level: number | N | LogMethodNames, logFn: LogFunction) => {
         const logLevel = typeof level === 'string' ? store.logLevelStore.getLevel(level)! : level
         if (shouldLog(store, logLevel, logger.level)) {
           const methodName = store.logLevelStore.getName(logLevel)

--- a/packages/log/ts/standardLog.spec.ts
+++ b/packages/log/ts/standardLog.spec.ts
@@ -117,8 +117,7 @@ describe('standardLog.getLogger()', () => {
   it('needs to cast Logger when wrapped', () => {
     function wrapper<N extends string = LogMethodNames>(options: StandardLogOptions<N>) {
       const sl = createStandardLog<N>(options)
-      // since `N` is generic, just `Logger<N>` will not have the default log method names.
-      const log = sl.getLogger('local') as Logger<LogMethodNames>
+      const log = sl.getLogger('local')
       expect(log.info).toBeDefined()
       return sl
     }
@@ -126,6 +125,9 @@ describe('standardLog.getLogger()', () => {
     const sl = wrapper({ customLevels: { 'cust': 123 } })
     const actual = sl.getLogger('c')
     expect(actual.cust).toBeDefined()
+
+    // make sure the logger outside also get default log methods
+    expect(actual.error).toBeDefined()
   })
 
   describe('log levels', () => {

--- a/packages/log/ts/standardLog.ts
+++ b/packages/log/ts/standardLog.ts
@@ -9,7 +9,7 @@ export interface StandardLogInstance<N extends string = LogMethodNames> {
   logLevel: number,
   toLogLevelName(level: number): string,
   toLogLevel(name: N): number,
-  getLogger(id: string, options?: LoggerOptions): Logger<N>
+  getLogger(id: string, options?: LoggerOptions): Logger<N | LogMethodNames>
 }
 
 export interface StandardLog<N extends string = LogMethodNames> extends Readonly<StandardLogInstance<N>> {

--- a/packages/log/ts/types.ts
+++ b/packages/log/ts/types.ts
@@ -11,7 +11,7 @@ export interface LoggerOptions extends StackTraceMeta {
   writeTo?: LogReporter | ReporterFilter
 }
 
-export type Logger<T extends string = LogMethodNames> = {
+export type Logger<N extends string = LogMethodNames> = {
   readonly id: string,
   /**
    * Logger local log level.
@@ -22,12 +22,12 @@ export type Logger<T extends string = LogMethodNames> = {
    * This is useful during debugging to check for steps executed.
    */
   count(...args: any[]): void,
-  on(level: number | T, logFunction: LogFunction): void,
+  on(level: number | N, logFunction: LogFunction): void,
   /**
    * Write custom log entries.
    */
   write(entry: LogEntry): void
-} & { [k in T]: LogMethod }
+} & { [k in N]: LogMethod }
 
 /**
  * Names of the standard log methods.


### PR DESCRIPTION
in generic environment.

Fixing it again as the previous change reverted it.