### PR TITLE
chore: upgrade to pnpm 11.1.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 public-hoist-pattern[]=*storybook*
+minimumreleaseage=1440

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"typescript": "^5.0.0",
 		"vitest": "^4.0.18"
 	},
-	"packageManager": "pnpm@10.33.0",
+	"packageManager": "pnpm@11.1.3",
 	"pnpm": {
 		"overrides": {
 			"path-to-regexp@<0.1.13": ">=0.1.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  path-to-regexp@<0.1.13: '>=0.1.13'
-
 importers:
 
   .:
@@ -28,10 +25,10 @@ importers:
         version: 2.3.1(@biomejs/biome@2.4.4)
       '@repobuddy/vitest':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       husky:
         specifier: ^9.0.0
         version: 9.1.7
@@ -49,7 +46,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   examples/solid:
     dependencies:
@@ -71,7 +68,7 @@ importers:
         version: 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/addon-essentials':
         specifier: ^6.5.12
-        version: 6.5.16(@babel/core@7.28.5)(@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(lightningcss@1.32.0)(postcss@7.0.39)(typescript@4.9.5))(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+        version: 6.5.16(@babel/core@7.28.5)(@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(postcss@7.0.39)(typescript@4.9.5))(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))
       '@storybook/addon-interactions':
         specifier: ^6.5.12
         version: 6.5.16(@types/react@19.2.7)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)
@@ -80,25 +77,25 @@ importers:
         version: 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/builder-vite':
         specifier: ^0.2.3
-        version: 0.2.7(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 0.2.7(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@storybook/html':
         specifier: ^6.5.12
-        version: 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(lightningcss@1.32.0)(postcss@7.0.39)(typescript@4.9.5)
+        version: 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(postcss@7.0.39)(typescript@4.9.5)
       '@storybook/testing-library':
         specifier: ^0.0.13
         version: 0.0.13(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       babel-loader:
         specifier: ^8.2.5
-        version: 8.4.1(@babel/core@7.28.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+        version: 8.4.1(@babel/core@7.28.5)(webpack@5.106.2(postcss@7.0.39))
       typescript:
         specifier: ^4.8.4
         version: 4.9.5
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
       vite-plugin-solid:
         specifier: ^2.3.9
-        version: 2.11.10(solid-js@1.9.10)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.11.10(solid-js@1.9.10)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
 
   packages/color:
     dependencies:
@@ -114,7 +111,7 @@ importers:
     devDependencies:
       '@repobuddy/vitest':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@size-limit/preset-small-lib':
         specifier: ^9.0.0
         version: 9.0.0(size-limit@9.0.0)
@@ -165,10 +162,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
       webpack:
         specifier: ^5.74.0
-        version: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+        version: 5.106.2(webpack-cli@7.0.0)
       webpack-cli:
         specifier: ^7.0.0
         version: 7.0.0(webpack-bundle-analyzer@5.0.1)(webpack@5.106.2)
@@ -190,7 +187,7 @@ importers:
     devDependencies:
       '@repobuddy/vitest':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@size-limit/preset-small-lib':
         specifier: ^9.0.0
         version: 9.0.0(size-limit@9.0.0)
@@ -247,10 +244,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
       webpack:
         specifier: ^5.74.0
-        version: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+        version: 5.106.2(webpack-cli@7.0.0)
       webpack-bundle-analyzer:
         specifier: ^5.0.0
         version: 5.0.1
@@ -266,7 +263,7 @@ importers:
     devDependencies:
       '@repobuddy/vitest':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@size-limit/preset-small-lib':
         specifier: ^9.0.0
         version: 9.0.0(size-limit@9.0.0)
@@ -299,13 +296,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   packages/syslog:
     devDependencies:
       '@repobuddy/vitest':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@size-limit/preset-small-lib':
         specifier: ^9.0.0
         version: 9.0.0(size-limit@9.0.0)
@@ -350,10 +347,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
       webpack:
         specifier: ^5.74.0
-        version: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+        version: 5.106.2(webpack-cli@7.0.0)
       webpack-cli:
         specifier: ^7.0.0
         version: 7.0.0(webpack-bundle-analyzer@5.0.1)(webpack@5.106.2)
@@ -3654,10 +3651,6 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
   detect-package-manager@2.0.1:
     resolution: {integrity: sha512-j/lJHyoLlWi6G1LDdLgvUtz60Zo5GEj+sVYtTVXnYLDPuzgC3llMxonXym9zIwhhUII8vjdw0LXxavpLqTbl1A==}
     engines: {node: '>=12'}
@@ -5082,80 +5075,6 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
-    engines: {node: '>= 12.0.0'}
-
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -5861,8 +5780,8 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-type@1.1.0:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
@@ -7637,11 +7556,6 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -9239,7 +9153,7 @@ snapshots:
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.0.5(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.0.5(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       glob: 7.2.3
@@ -9247,7 +9161,7 @@ snapshots:
       magic-string: 0.26.7
       react-docgen-typescript: 2.4.0(typescript@4.9.5)
       typescript: 4.9.5
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9360,10 +9274,10 @@ snapshots:
 
   '@repobuddy/test@1.0.0': {}
 
-  '@repobuddy/vitest@2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@repobuddy/vitest@2.1.1(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
       '@repobuddy/test': 1.0.0
-      vitest: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -9539,7 +9453,7 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-docs@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))':
+  '@storybook/addon-docs@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))':
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
@@ -9559,7 +9473,7 @@ snapshots:
       '@storybook/source-loader': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/store': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/theming': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      babel-loader: 8.4.1(@babel/core@7.28.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      babel-loader: 8.4.1(@babel/core@7.28.5)(webpack@5.106.2(postcss@7.0.39))
       core-js: 3.47.0
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -9582,13 +9496,13 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-essentials@6.5.16(@babel/core@7.28.5)(@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(lightningcss@1.32.0)(postcss@7.0.39)(typescript@4.9.5))(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))':
+  '@storybook/addon-essentials@6.5.16(@babel/core@7.28.5)(@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(postcss@7.0.39)(typescript@4.9.5))(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))':
     dependencies:
       '@babel/core': 7.28.5
       '@storybook/addon-actions': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/addon-backgrounds': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/addon-controls': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)
-      '@storybook/addon-docs': 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      '@storybook/addon-docs': 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))
       '@storybook/addon-measure': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/addon-outline': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/addon-toolbars': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -9601,10 +9515,10 @@ snapshots:
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@storybook/html': 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(lightningcss@1.32.0)(postcss@7.0.39)(typescript@4.9.5)
+      '@storybook/html': 6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(postcss@7.0.39)(typescript@4.9.5)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - eslint
@@ -9759,15 +9673,15 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/builder-vite@0.2.7(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@storybook/builder-vite@0.2.7(@babel/core@7.28.5)(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.5(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.5(typescript@4.9.5)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@storybook/core-common': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)
       '@storybook/mdx1-csf': 0.0.4(@babel/core@7.28.5)(react@16.14.0)
       '@storybook/node-logger': 6.5.16
       '@storybook/semver': 7.3.2
       '@storybook/source-loader': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@vitejs/plugin-react': 2.2.0(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+      '@vitejs/plugin-react': 2.2.0(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       ast-types: 0.14.2
       es-module-lexer: 0.9.3
       glob: 7.2.3
@@ -9776,7 +9690,7 @@ snapshots:
       react-docgen: 6.0.0-alpha.3
       slash: 3.0.0
       sveltedoc-parser: 4.2.1
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
     transitivePeerDependencies:
       - '@babel/core'
       - eslint
@@ -9814,7 +9728,7 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.47.0
       css-loader: 3.6.0(webpack@4.47.0)
-      file-loader: 6.2.0(webpack@4.47.0)
+      file-loader: 6.2.0(webpack@5.106.2(postcss@7.0.39))
       find-up: 5.0.0
       fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.4.1)(typescript@4.9.5)(webpack@4.47.0)
       glob: 7.2.3
@@ -9944,7 +9858,7 @@ snapshots:
     optionalDependencies:
       typescript: 4.9.5
 
-  '@storybook/core-client@6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))':
+  '@storybook/core-client@6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))':
     dependencies:
       '@storybook/addons': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/channel-postmessage': 6.5.16
@@ -9968,7 +9882,7 @@ snapshots:
       ts-dedent: 2.2.0
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
     optionalDependencies:
       typescript: 4.9.5
 
@@ -10102,13 +10016,13 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/core@6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))':
+  '@storybook/core@6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))':
     dependencies:
-      '@storybook/core-client': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      '@storybook/core-client': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))
       '@storybook/core-server': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -10160,11 +10074,11 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(lightningcss@1.32.0)(postcss@7.0.39)(typescript@4.9.5)':
+  '@storybook/html@6.5.16(@babel/core@7.28.5)(eslint@8.4.1)(postcss@7.0.39)(typescript@4.9.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@storybook/addons': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@storybook/core': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      '@storybook/core': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.106.2(postcss@7.0.39))
       '@storybook/core-common': 6.5.16(eslint@8.4.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@4.9.5)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -10174,13 +10088,13 @@ snapshots:
       '@types/webpack-env': 1.18.8
       core-js: 3.47.0
       global: 4.4.0
-      html-loader: 1.3.2(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      html-loader: 1.3.2(webpack@5.106.2(postcss@7.0.39))
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@storybook/builder-webpack5'
@@ -10238,7 +10152,7 @@ snapshots:
       core-js: 3.47.0
       css-loader: 3.6.0(webpack@4.47.0)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      file-loader: 6.2.0(webpack@4.47.0)
       find-up: 5.0.0
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2(webpack@4.47.0)
@@ -10635,7 +10549,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@2.2.0(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react@2.2.0(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
@@ -10644,11 +10558,11 @@ snapshots:
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       magic-string: 0.26.7
       react-refresh: 0.14.2
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -10660,7 +10574,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -10671,13 +10585,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.18(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -11206,14 +11120,14 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 4.47.0
 
-  babel-loader@8.4.1(@babel/core@7.28.5)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39)):
+  babel-loader@8.4.1(@babel/core@7.28.5)(webpack@5.106.2(postcss@7.0.39)):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
 
   babel-plugin-apply-mdx-type-prop@1.6.22(@babel/core@7.12.9):
     dependencies:
@@ -11777,7 +11691,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+      webpack: 5.106.2(webpack-cli@7.0.0)
 
   compression@1.8.1:
     dependencies:
@@ -12148,9 +12062,6 @@ snapshots:
   detect-file@1.0.0: {}
 
   detect-indent@6.1.0: {}
-
-  detect-libc@2.1.2:
-    optional: true
 
   detect-package-manager@2.0.1:
     dependencies:
@@ -12662,7 +12573,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 8.4.2
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -12758,11 +12669,11 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 4.47.0
 
-  file-loader@6.2.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39)):
+  file-loader@6.2.0(webpack@5.106.2(postcss@7.0.39)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
 
   file-system-cache@1.1.0:
     dependencies:
@@ -13301,13 +13212,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-loader@1.3.2(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39)):
+  html-loader@1.3.2(webpack@5.106.2(postcss@7.0.39)):
     dependencies:
       html-minifier-terser: 5.1.1
       htmlparser2: 4.1.0
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
 
   html-minifier-terser@5.1.1:
     dependencies:
@@ -13864,56 +13775,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lightningcss-android-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
-
-  lightningcss@1.32.0:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
-    optional: true
 
   lilconfig@2.1.0: {}
 
@@ -14672,7 +14533,7 @@ snapshots:
       lru-cache: 11.2.2
       minipass: 7.1.2
 
-  path-to-regexp@8.4.2: {}
+  path-to-regexp@0.1.12: {}
 
   path-type@1.1.0:
     dependencies:
@@ -15899,26 +15760,23 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  terser-webpack-plugin@5.6.0(lightningcss@1.32.0)(postcss@7.0.39)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39)):
+  terser-webpack-plugin@5.6.0(postcss@7.0.39)(webpack@5.106.2(postcss@7.0.39)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.1
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@7.0.39)
+      webpack: 5.106.2(postcss@7.0.39)
     optionalDependencies:
-      lightningcss: 1.32.0
       postcss: 7.0.39
 
-  terser-webpack-plugin@5.6.0(lightningcss@1.32.0)(webpack@5.106.2):
+  terser-webpack-plugin@5.6.0(webpack@5.106.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.1
-      webpack: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
-    optionalDependencies:
-      lightningcss: 1.32.0
+      webpack: 5.106.2(webpack-cli@7.0.0)
 
   terser@4.8.1:
     dependencies:
@@ -16028,7 +15886,7 @@ snapshots:
       semver: 7.7.3
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+      webpack: 5.106.2(webpack-cli@7.0.0)
 
   ts-pnp@1.2.0(typescript@4.9.5):
     optionalDependencies:
@@ -16273,7 +16131,7 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 4.47.0
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      file-loader: 6.2.0(webpack@5.106.2(postcss@7.0.39))
 
   url@0.11.4:
     dependencies:
@@ -16334,7 +16192,7 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)):
     dependencies:
       '@babel/core': 7.28.5
       '@types/babel__core': 7.20.5
@@ -16342,12 +16200,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
+      vitefu: 1.1.1(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1):
+  vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16359,18 +16217,16 @@ snapshots:
       '@types/node': 18.19.130
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.32.0
       terser: 5.44.1
-      yaml: 2.8.1
 
-  vitefu@1.1.1(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)):
+  vitefu@1.1.1(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
 
-  vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -16387,7 +16243,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@18.19.130)(jiti@2.6.1)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.130
@@ -16468,7 +16324,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0)
+      webpack: 5.106.2(webpack-cli@7.0.0)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 5.0.1
@@ -16544,7 +16400,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39):
+  webpack@5.106.2(postcss@7.0.39):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16567,7 +16423,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(lightningcss@1.32.0)(postcss@7.0.39)(webpack@5.106.2(lightningcss@1.32.0)(postcss@7.0.39))
+      terser-webpack-plugin: 5.6.0(postcss@7.0.39)(webpack@5.106.2(postcss@7.0.39))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:
@@ -16584,7 +16440,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.2(lightningcss@1.32.0)(webpack-cli@7.0.0):
+  webpack@5.106.2(webpack-cli@7.0.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16607,7 +16463,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(lightningcss@1.32.0)(webpack@5.106.2)
+      terser-webpack-plugin: 5.6.0(webpack@5.106.2)
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
@@ -16751,9 +16607,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.3: {}
-
-  yaml@2.8.1:
-    optional: true
 
   yargs-parser@20.2.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - packages/*
   - examples/*
+allowBuilds:
+  core-js: true
+  esbuild: true


### PR DESCRIPTION
## Summary

- Upgrade pnpm to `11.1.3`
- Add `minimumreleaseage=1440` to `.npmrc` — blocks packages published in the last 24h, reducing supply chain attack risk
- Remove obsolete `use-lockfile-v6` setting (default since pnpm 9)
- Approve native build scripts via `pnpm-workspace.yaml`

## Test plan
- [ ] CI passes